### PR TITLE
Added requirements.txt and install line to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ A simple python script to query the MITRE ATT&amp;CK API for tactics, techniques
 Use one of two methods:
 - If (python3 is installed): 
     - Download script from git
+    - `pip3 install -r requirements.txt`
     - `python3 attackintel.py`
 - Else: 
     - Cut & paste script from git into your favorite [online python emulator](https://repl.it/languages/python3)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+termcolor

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
 termcolor
+requests
+time


### PR DESCRIPTION
I'm not familiar with the automatic pip install function you put in the script, in any case it didn't automatically grab the libraries on two of my dev machines.

So if it's beneficial, I've added a requirements.txt with the libraries and added a line in the README explaining the process of `pip3 install` from a file.